### PR TITLE
Resolves the acronym "RTL".

### DIFF
--- a/constraints.md
+++ b/constraints.md
@@ -9,7 +9,7 @@
 * We expect to have roughtly N topics of content.
 
 * The content needs to be translated into N languages.
-  - Are any of those languages RTL?
+  - Are any of those languages RTL (right-to-left)?
 
 * We expect to have roughtly N regular contributors.
 


### PR DESCRIPTION
I had to look it up. Given that the audience for this document is people who
are not documentation experts, I suspect a number of other readers may also
need this acronym resolved.